### PR TITLE
changed attribute names and added customization properties

### DIFF
--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
@@ -264,13 +264,6 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
             //switch page links to column identifier
          }
          else if (TAG_COLUMN.equals(qName)){
-            SSpan colSpan= SaltFactory.eINSTANCE.createSSpan();
-            //colSpan.createSAnnotation(null, TAG_COLUMN, attributes.getValue(ATT_ID));
-            // ATT_ID contains the id of the column element (e.g. "c1"), but this has to be changed
-            // to alphabetic numbering ("c1" -> "a")
-            colSpan.createSAnnotation(null, TAG_COLUMN, Character.toString(current_column++));
-
-            getSDocument().getSDocumentGraph().addSNode(colSpan);
             String[] parts= attributes.getValue(ATT_RANGE).split("[.][.]");
             String start= null;
             String end= null;
@@ -280,8 +273,6 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
                   end= parts[1];
                else end= parts[0];
             }
-            columnStart.put(start, colSpan);
-            columnEnd.put(end, colSpan);
 
             String id= attributes.getValue(ATT_ID);
             //switch page links to column identifier
@@ -290,6 +281,8 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
                {
                   pageStart.remove(id);
                   pageStart.put(start, pageSpan);
+		  // reset column count
+		  current_column = 'a';
                }
                pageSpan= pageEnd.get(id);
                if (pageSpan!= null)
@@ -298,6 +291,17 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
                   pageEnd.put(end, pageSpan);
                }
             //switch page links to column identifier
+
+            SSpan colSpan= SaltFactory.eINSTANCE.createSSpan();
+            //colSpan.createSAnnotation(null, TAG_COLUMN, attributes.getValue(ATT_ID));
+            // ATT_ID contains the id of the column element (e.g. "c1"), but this has to be changed
+            // to alphabetic numbering ("c1" -> "a")
+            colSpan.createSAnnotation(null, TAG_COLUMN, Character.toString(current_column++));
+
+            getSDocument().getSDocumentGraph().addSNode(colSpan);
+
+            columnStart.put(start, colSpan);
+            columnEnd.put(end, colSpan);
          }
          else if (TAG_LINE.equals(qName)){
             SSpan sSpan= SaltFactory.eINSTANCE.createSSpan();

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
@@ -198,7 +198,7 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
             SSpan colSpan= SaltFactory.eINSTANCE.createSSpan();
             // TODO there should be a span for the page no independent of the side
             colSpan.createSAnnotation(null, ATT_SIDE, attributes.getValue(ATT_SIDE));
-            colSpan.createSAnnotation(null, "page", attributes.getValue("count"));
+            colSpan.createSAnnotation(null, "page", attributes.getValue(ATT_NO));
 
             getSDocument().getSDocumentGraph().addSNode(colSpan);
             String[] parts= attributes.getValue(ATT_RANGE).split("[.][.]");
@@ -213,7 +213,7 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
          }
          else if (TAG_MOD.equals(qName)){
             SSpan span= SaltFactory.eINSTANCE.createSSpan();
-            span.createSAnnotation(null, SEGMENTATION_NAME_MOD, StringEscapeUtils.unescapeHtml4(attributes.getValue("simple")));
+            span.createSAnnotation(null, SEGMENTATION_NAME_MOD, StringEscapeUtils.unescapeHtml4(attributes.getValue(ATT_ASCII)));
             getSDocument().getSDocumentGraph().addSNode(span);
             addOrderRelation(last_mod, span, SEGMENTATION_NAME_MOD);
             last_mod = span;
@@ -293,7 +293,7 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
          }
          else if (TAG_LINE.equals(qName)){
             SSpan sSpan= SaltFactory.eINSTANCE.createSSpan();
-            sSpan.createSAnnotation(null, TAG_LINE, attributes.getValue("count"));
+            sSpan.createSAnnotation(null, TAG_LINE, attributes.getValue(ATT_NAME));
             getSDocument().getSDocumentGraph().addSNode(sSpan);
             String[] parts= attributes.getValue(ATT_RANGE).split("[.][.]");
             String start= null;

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
@@ -50,6 +50,9 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
    private String mod_tok_textlayer = ATT_ASCII; // one of "trans", "utf" and "ascii"
    private String dipl_tok_textlayer = ATT_UTF;  // one of "trans" and "utf"
 
+   /** defines whether the token layer should be exported **/
+   private boolean exportTokenLayer = true;
+
    /**
     * {@inheritDoc PepperMapper#setSDocument(SDocument)}
     *
@@ -188,7 +191,7 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
          }
          else if (TAG_TEXT.equals(qName)){
          }
-         else if (TAG_TOKEN.equals(qName)){
+         else if (exportTokenLayer && TAG_TOKEN.equals(qName)){
             openToken= SaltFactory.eINSTANCE.createSSpan();
             openToken.createSAnnotation(null,
                                         SEGMENTATION_NAME_TOKEN,
@@ -523,7 +526,9 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
                  // create a tok to span dipl/mod/token on
                  SToken tok = getSDocument().getSDocumentGraph().createSToken(sTextualDS, left_pos, right_pos);
                  // span the token on the tok
-                 span_on_tok(openToken, tok);
+                 if (exportTokenLayer) {
+                     span_on_tok(openToken, tok);
+                 }
                  // span the last retrieved dipl on the tok
                  span_on_tok(last_dipl, tok);
                  // connect the dipl to line/column/... spans
@@ -537,7 +542,9 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
 
             resetOpenDipls();
             resetOpenMods();
-            getSNodeStack().pop();
+            if (exportTokenLayer) {
+                getSNodeStack().pop();
+            }
          }// tag is TAG_TOKEN
          else if (TAG_DIPL.equals(qName))
          {// tag is TAG_DIPL
@@ -568,4 +575,9 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
            this.dipl_tok_textlayer = textlayer;
        }
    }
+
+   public void setExportTokenLayer(boolean exportTokenLayer) {
+       this.exportTokenLayer = exportTokenLayer;
+   }
+
 }

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXML2SaltMapper.java
@@ -45,6 +45,11 @@ import de.hu_berlin.german.korpling.saltnpepper.salt.saltCore.SNode;
 
 public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper, CoraXMLDictionary
 {
+
+   /** defines which textual representation is used for the dipl and mod tokens **/
+   private String mod_tok_textlayer = ATT_ASCII; // one of "trans", "utf" and "ascii"
+   private String dipl_tok_textlayer = ATT_UTF;  // one of "trans" and "utf"
+
    /**
     * {@inheritDoc PepperMapper#setSDocument(SDocument)}
     *
@@ -213,7 +218,7 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
          }
          else if (TAG_MOD.equals(qName)){
             SSpan span= SaltFactory.eINSTANCE.createSSpan();
-            span.createSAnnotation(null, SEGMENTATION_NAME_MOD, StringEscapeUtils.unescapeHtml4(attributes.getValue(ATT_ASCII)));
+            span.createSAnnotation(null, SEGMENTATION_NAME_MOD, StringEscapeUtils.unescapeHtml4(attributes.getValue(mod_tok_textlayer)));
             getSDocument().getSDocumentGraph().addSNode(span);
             addOrderRelation(last_mod, span, SEGMENTATION_NAME_MOD);
             last_mod = span;
@@ -222,7 +227,7 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
          }
          else if (TAG_DIPL.equals(qName)){
             SSpan span= SaltFactory.eINSTANCE.createSSpan();
-            span.createSAnnotation(null, SEGMENTATION_NAME_DIPL, StringEscapeUtils.unescapeHtml4(attributes.getValue(ATT_UTF)));
+            span.createSAnnotation(null, SEGMENTATION_NAME_DIPL, StringEscapeUtils.unescapeHtml4(attributes.getValue(dipl_tok_textlayer)));
             getSDocument().getSDocumentGraph().addSNode(span);
             addOrderRelation(last_dipl, span, SEGMENTATION_NAME_DIPL);
             last_dipl = span;
@@ -550,5 +555,17 @@ public class CoraXML2SaltMapper extends PepperMapperImpl implements PepperMapper
          }
          getXMLELementStack().pop();
       }
+   }
+
+   // TODO: deal with invalid values for textlayer
+   public void setModTokTextlayer(String textlayer) {
+       if (textlayer.equals(ATT_ASCII) || textlayer.equals(ATT_UTF) || textlayer.equals(ATT_TRANS)) {
+           this.mod_tok_textlayer = textlayer;
+       }
+   }
+   public void setDiplTokTextlayer(String textlayer) {
+       if (textlayer.equals(ATT_UTF) || textlayer.equals(ATT_TRANS)) {
+           this.dipl_tok_textlayer = textlayer;
+       }
    }
 }

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporter.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporter.java
@@ -36,8 +36,12 @@ import de.hu_berlin.german.korpling.saltnpepper.salt.saltCore.SElementId;
  *
  */
 @Component(name="CoraXMLImporterComponent", factory="PepperImporterComponentFactory")
-public class CoraXMLImporter extends PepperImporterImpl implements PepperImporter
+public class CoraXMLImporter extends PepperImporterImpl implements PepperImporter, CoraXMLDictionary
 {
+
+    //** customization properties */
+    private String mod_tok_textlayer = ATT_ASCII;
+    private String dipl_tok_textlayer = ATT_UTF;
 
 // =================================================== mandatory ===================================================
 	/**
@@ -50,6 +54,7 @@ public class CoraXMLImporter extends PepperImporterImpl implements PepperImporte
 	public CoraXMLImporter()
 	{
 		super();
+		setProperties(new CoraXMLImporterProperties());
 		this.setName("CoraXMLImporter");
 		setSupplierContact(URI.createURI("saltnpepper@lists.hu-berlin.de"));
 		setSupplierHomepage(URI.createURI("https://github.com/korpling/pepperModules-CoraXMLModules"));
@@ -62,6 +67,8 @@ public class CoraXMLImporter extends PepperImporterImpl implements PepperImporte
 	public PepperMapper createPepperMapper(SElementId sElementId)
 	{
 		CoraXML2SaltMapper mapper = new CoraXML2SaltMapper();
+		mapper.setModTokTextlayer(mod_tok_textlayer);
+		mapper.setDiplTokTextlayer(dipl_tok_textlayer);
 		return(mapper);
 	}
 	
@@ -92,6 +99,10 @@ public class CoraXMLImporter extends PepperImporterImpl implements PepperImporte
 	@Override
 	public boolean isReadyToStart() throws PepperModuleNotReadyException
 	{
+	    if (this.getProperties() != null) {
+		mod_tok_textlayer = ((CoraXMLImporterProperties) this.getProperties()).getModTokTextlayer();
+		dipl_tok_textlayer = ((CoraXMLImporterProperties) this.getProperties()).getDiplTokTextlayer();
+	    }
 		//TODO make some initializations if necessary
 		return(super.isReadyToStart());
 	}

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporter.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporter.java
@@ -42,6 +42,7 @@ public class CoraXMLImporter extends PepperImporterImpl implements PepperImporte
     //** customization properties */
     private String mod_tok_textlayer = ATT_ASCII;
     private String dipl_tok_textlayer = ATT_UTF;
+    private boolean export_token_layer = true;
 
 // =================================================== mandatory ===================================================
 	/**
@@ -69,6 +70,7 @@ public class CoraXMLImporter extends PepperImporterImpl implements PepperImporte
 		CoraXML2SaltMapper mapper = new CoraXML2SaltMapper();
 		mapper.setModTokTextlayer(mod_tok_textlayer);
 		mapper.setDiplTokTextlayer(dipl_tok_textlayer);
+		mapper.setExportTokenLayer(export_token_layer);
 		return(mapper);
 	}
 	
@@ -102,6 +104,8 @@ public class CoraXMLImporter extends PepperImporterImpl implements PepperImporte
 	    if (this.getProperties() != null) {
 		mod_tok_textlayer = ((CoraXMLImporterProperties) this.getProperties()).getModTokTextlayer();
 		dipl_tok_textlayer = ((CoraXMLImporterProperties) this.getProperties()).getDiplTokTextlayer();
+		export_token_layer = ((CoraXMLImporterProperties) this.getProperties()).getExportTokenLayer();
+
 	    }
 		//TODO make some initializations if necessary
 		return(super.isReadyToStart());

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporterProperties.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporterProperties.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2015 Humboldt-Universität zu Berlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package de.hu_berlin.german.korpling.saltnpepper.pepperModules.coraXMLModules;
+
+// import java.util.regex.Matcher;
+// import java.util.regex.Pattern;
+
+import de.hu_berlin.german.korpling.saltnpepper.pepper.modules.PepperModuleProperties;
+import de.hu_berlin.german.korpling.saltnpepper.pepper.modules.PepperModuleProperty;
+// import java.util.ArrayList;
+// import java.util.concurrent.ConcurrentHashMap;
+// import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Defines the properties to be used for the {@link CoraXMLImporter}.
+ *
+ * @author Fabian Barteld
+ *
+ */
+public class CoraXMLImporterProperties extends PepperModuleProperties implements CoraXMLDictionary {
+
+  public static final String PREFIX_TOKTEXT = "toktext.";
+
+  /**
+   * Name of properties which set the feature used for the token text.
+   */
+  public static final String PROP_TOKTEXT_MOD =  PREFIX_TOKTEXT + "mod";
+  public static final String PROP_TOKTEXT_DIPL =  PREFIX_TOKTEXT + "dipl";
+
+  public CoraXMLImporterProperties() {
+    this.addProperty(new PepperModuleProperty<>(PROP_TOKTEXT_MOD, String.class, "This property defines which attribute of the mod-Tag is used for the token texts (trans, utf or ascii). By default, the simplified ascii version is used (value:ascii)", ATT_ASCII, false));
+    this.addProperty(new PepperModuleProperty<>(PROP_TOKTEXT_DIPL, String.class, "This property defines which attribute of the dipl-Tag is used for the token texts (trans or utf). By default, the unicode version is used (value:utf)", ATT_UTF, false));
+  }
+
+  /** Returns the attribute to be used for the text of the dipl-Token
+   *
+   * @return
+   */
+  public String getDiplTokTextlayer() {
+    return ((String) this.getProperty(PROP_TOKTEXT_DIPL).getValue());
+  }
+    
+  /** Returns the attribute to be used for the text of the mod-Token
+   *
+   * @return
+   */
+  public String getModTokTextlayer() {
+    return ((String) this.getProperty(PROP_TOKTEXT_MOD).getValue());
+  }
+
+
+}

--- a/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporterProperties.java
+++ b/src/main/java/de/hu_berlin/german/korpling/saltnpepper/pepperModules/coraXMLModules/CoraXMLImporterProperties.java
@@ -17,14 +17,8 @@
  */
 package de.hu_berlin.german.korpling.saltnpepper.pepperModules.coraXMLModules;
 
-// import java.util.regex.Matcher;
-// import java.util.regex.Pattern;
-
 import de.hu_berlin.german.korpling.saltnpepper.pepper.modules.PepperModuleProperties;
 import de.hu_berlin.german.korpling.saltnpepper.pepper.modules.PepperModuleProperty;
-// import java.util.ArrayList;
-// import java.util.concurrent.ConcurrentHashMap;
-// import java.util.concurrent.ConcurrentMap;
 
 /**
  * Defines the properties to be used for the {@link CoraXMLImporter}.
@@ -35,6 +29,8 @@ import de.hu_berlin.german.korpling.saltnpepper.pepper.modules.PepperModulePrope
 public class CoraXMLImporterProperties extends PepperModuleProperties implements CoraXMLDictionary {
 
   public static final String PREFIX_TOKTEXT = "toktext.";
+  public static final String PREFIX_EXPORT = "export.";
+
 
   /**
    * Name of properties which set the feature used for the token text.
@@ -42,9 +38,16 @@ public class CoraXMLImporterProperties extends PepperModuleProperties implements
   public static final String PROP_TOKTEXT_MOD =  PREFIX_TOKTEXT + "mod";
   public static final String PROP_TOKTEXT_DIPL =  PREFIX_TOKTEXT + "dipl";
 
+  /**
+   * Name of properties which define whether a layer is exported.
+   */
+  public static final String PROP_EXPORT_TOKEN = PREFIX_EXPORT + "token";
+
   public CoraXMLImporterProperties() {
     this.addProperty(new PepperModuleProperty<>(PROP_TOKTEXT_MOD, String.class, "This property defines which attribute of the mod-Tag is used for the token texts (trans, utf or ascii). By default, the simplified ascii version is used (value:ascii)", ATT_ASCII, false));
     this.addProperty(new PepperModuleProperty<>(PROP_TOKTEXT_DIPL, String.class, "This property defines which attribute of the dipl-Tag is used for the token texts (trans or utf). By default, the unicode version is used (value:utf)", ATT_UTF, false));
+    this.addProperty(new PepperModuleProperty<>(PROP_EXPORT_TOKEN, Boolean.class, "This property defines whether the token layer is exported. By default, it is exported (value:true)", Boolean.TRUE, false));
+
   }
 
   /** Returns the attribute to be used for the text of the dipl-Token
@@ -63,5 +66,12 @@ public class CoraXMLImporterProperties extends PepperModuleProperties implements
     return ((String) this.getProperty(PROP_TOKTEXT_MOD).getValue());
   }
 
+   /** Returns whether the token-layer should be exported
+   *
+   * @return
+   */
+  public boolean getExportTokenLayer() {
+    return ((Boolean) this.getProperty(PROP_EXPORT_TOKEN).getValue());
+  }
 
 }


### PR DESCRIPTION
Changed the the attribute names of page number and line number back to standard CoraXML and
added customization properties to choose the attributes used for the dipl_tok and mod_tok text.
